### PR TITLE
Fix embassy-usb panic from configuration

### DIFF
--- a/src/task.rs
+++ b/src/task.rs
@@ -79,11 +79,6 @@ pub async fn run<D: Driver<'static>>(driver: D, size: usize, config: Option<Conf
         Some(c) => c,
     };
 
-    // Configure the device class.
-    config.device_class = 0x02;
-    config.device_sub_class = 0x02;
-    config.device_protocol = 0x01;
-
     // Get the static buffers.
     let (devdesc, cfgdesc, bosdesc, ctrlbuf) = unsafe {(
         &mut DEVBUF,


### PR DESCRIPTION
embassy-usb [expects a particular config](https://github.com/embassy-rs/embassy/blob/3e8d8fec15286eb25b8bba7d103c8fc279544551/embassy-usb/src/builder.rs#L175-L180) if composite_with_iads is set (the default) and the previous settings would cause an assertion to fail, crashing the firmware.

According to [the Nordic documentation](https://docs.nordicsemi.com/bundle/ncs-1.9.1/page/kconfig/CONFIG_CDC_ACM_IAD.html):

> IAD should not be required for non-composite CDC ACM device, but Windows 7 fails to properly enumerate without it. Enable if you want CDC ACM to work with Windows 7.

Ideally we'd just use the standard USB serial class code (0x02) rather than the one for IADs (0xEF), and Windows 7 is now out of extended support, but this is still the default in embassy-usb and it makes sense just to track what it does.

Since we're not patching the given config, these expectations should be spelled out to the user (see #1).