### PR TITLE
Fix buffer swapping and resulting frame corruption

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -86,7 +86,7 @@ impl Controller {
         unsafe { BUFFERS[self.current as usize].flush() };
 
         // Swap the buffers.
-        self.current.swap();
+        self.current = self.current.swap();
     }
 
     /// Writes to the current buffer.
@@ -112,7 +112,7 @@ impl Controller {
         }
 
         // Check the other buffer.
-        self.current.swap();
+        self.swap();
 
         // Get the alternate buffer.
         let alternate = unsafe { &mut BUFFERS[self.current as usize] };


### PR DESCRIPTION
The two buffers were not actually being swapped, resulting in lost writes to the "alternate" buffer (since it was the "current" buffer and was in the flushing state). This manifested as corrupted defmt frames.

For me, this was either a frame that the defmt parser explicitly recognises as "malformed", or a frame containing strange values (actually the following frame's values misinterpreted) due to losing the end-of-value/end-of-frame markers.

For example:
```
# sequence: 
#      n   +10   +11   +12   +13
INFO  38    48    49    50    51
INFO  39    49    50    51    52
INFO  40    50    144115188075855923    56075093027072    57174604644352
INFO  42    52    53    54    55
INFO  43    53    54    55    56
```
Note that the message with n = 41 is missing, because defmt interprets its bytes as being part of the n = 40 message.

The cause is ultimately confusion between `Controller::swap`, which is meant to mutate the controller by swapping the active buffer, and `BufferIndex::swap`, which returns the "other" or "opposite" value to `self`.

A refactor should make this distinction clear.