### PR TITLE
examples: add nrf52840 hello world

### DIFF
--- a/device-examples/README.md
+++ b/device-examples/README.md
@@ -7,3 +7,4 @@ examples are known to work on those chips.
 
 - `embassy-rp`: both RP2040 and RP235x
 - `esp-hal`: ESP32-S2
+- `embassy-nrf`: nRF52840

--- a/device-examples/nrf52840/.cargo/config.toml
+++ b/device-examples/nrf52840/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "thumbv7em-none-eabihf"
+
+[env]
+DEFMT_LOG="debug"

--- a/device-examples/nrf52840/Cargo.toml
+++ b/device-examples/nrf52840/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "defmtusb-nrf52840-helloworld"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+cortex-m-rt = "0.7.3"
+cortex-m = { version = "0.7.3", features = ["critical-section-single-core"] }
+embassy-executor = { version = "0.9.1", features = ["defmt", "arch-cortex-m", "executor-thread"] }
+embassy-nrf = { version = "0.9.0", features = ["defmt", "nrf52840", "time", "time-driver-rtc1"] }
+embassy-time = { version = "0.5.0", features = ["defmt"] }
+embassy-usb = { version = "0.5.1", features = ["defmt"] }
+defmt = "1.0.1"
+defmt-embassy-usbserial = { version = "0.2.1", default-features = false, features = ["buffersize-64"] }
+panic-halt = "1.0.0"
+embedded-hal-async = "1.0.0"
+
+[profile.release]
+opt-level = "s"

--- a/device-examples/nrf52840/README.md
+++ b/device-examples/nrf52840/README.md
@@ -1,0 +1,5 @@
+# Hello world example on nRF52840
+
+Validated using a Seeed Studio XIAO nRF52840.
+
+This specific memory.x corresponds to version S140 7.3.0 of the SoftDevice protocol stack and may differ for your chip.

--- a/device-examples/nrf52840/build.rs
+++ b/device-examples/nrf52840/build.rs
@@ -1,0 +1,35 @@
+//! This build script copies the `memory.x` file from the crate root into
+//! a directory where the linker can always find it at build time.
+//! For many projects this is optional, as the linker always searches the
+//! project root directory -- wherever `Cargo.toml` is. However, if you
+//! are using a workspace or have a more complicated build setup, this
+//! build script becomes required. Additionally, by requesting that
+//! Cargo re-run the build script whenever `memory.x` is changed,
+//! updating `memory.x` ensures a rebuild of the application with the
+//! new memory settings.
+
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::PathBuf;
+
+fn main() {
+    // Put `memory.x` in our output directory and ensure it's
+    // on the linker search path.
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    File::create(out.join("memory.x"))
+        .unwrap()
+        .write_all(include_bytes!("memory.x"))
+        .unwrap();
+    println!("cargo:rustc-link-search={}", out.display());
+
+    // By default, Cargo will re-run a build script whenever
+    // any file in the project changes. By specifying `memory.x`
+    // here, we ensure the build script is only re-run when
+    // `memory.x` is changed.
+    println!("cargo:rerun-if-changed=memory.x");
+
+    println!("cargo:rustc-link-arg-bins=--nmagic");
+    println!("cargo:rustc-link-arg-bins=-Tlink.x");
+    println!("cargo:rustc-link-arg-bins=-Tdefmt.x");
+}

--- a/device-examples/nrf52840/memory.x
+++ b/device-examples/nrf52840/memory.x
@@ -1,0 +1,17 @@
+MEMORY
+{
+  /* 
+    These values are confirmed working for S140 7.3.0
+    Flash 1MB total:
+      - SoftDevice 156K
+      - Application 868K
+
+    RAM 256K total:
+      - SoftDevice: 128K
+      - Application: 128K
+
+    RAM usage for SoftDevice depends on runtime configuration.
+  */
+  FLASH (rx)     : ORIGIN = 0x00027000, LENGTH = 868K
+  RAM (rwx)      : ORIGIN = 0x20020000, LENGTH = 128K
+}

--- a/device-examples/nrf52840/src/main.rs
+++ b/device-examples/nrf52840/src/main.rs
@@ -1,0 +1,50 @@
+#![no_std]
+#![no_main]
+
+use defmt::info;
+use embassy_executor::Spawner;
+use embedded_hal_async::delay::DelayNs;
+use embassy_nrf::peripherals::USBD;
+use embassy_nrf::usb::Driver;
+use embassy_nrf::usb::vbus_detect::HardwareVbusDetect;
+use embassy_nrf::{Peri, bind_interrupts, peripherals, usb};
+use embassy_time::Instant;
+use embassy_usb::Config;
+
+use defmt as _;
+use panic_halt as _;
+
+bind_interrupts!(struct Irqs {
+    USBD => usb::InterruptHandler<peripherals::USBD>;
+    CLOCK_POWER => usb::vbus_detect::InterruptHandler;
+});
+
+#[embassy_executor::task]
+async fn defmtusb_wrapper(usbd: Peri<'static, USBD>){
+    let driver = Driver::new(usbd, Irqs, HardwareVbusDetect::new(Irqs));
+
+    let mut config = Config::new(0x16c0, 0x27dd);
+    config.serial_number = Some("defmt");
+    config.max_packet_size_0 = 64;
+    config.composite_with_iads = true;
+    config.device_class = 0xEF;
+    config.device_sub_class = 0x02;
+    config.device_protocol = 0x01;
+
+    defmt_embassy_usbserial::run(driver, config).await;
+}
+
+#[embassy_executor::main]
+async fn main(spawner: Spawner) {
+    let mut delay = embassy_time::Delay;
+    let config = embassy_nrf::config::Config::default();
+    let p = embassy_nrf::init(config);
+    spawner.must_spawn(defmtusb_wrapper(p.USBD));
+
+    info!("Starting loop");
+
+    loop {
+        info!("Hello, world!  {=u64:tms}", Instant::now().as_millis());
+        delay.delay_ms(100).await;
+    }
+}


### PR DESCRIPTION
This adds a new example based on the nRF52840 using the embassy-nrf HAL.

I've kept the scope of the example to the same timestamp-loop and used only the necessary imports.

There is a slight gotcha in terms of the memory.x:
Depending on the pre-flashed SoftDevice version, a starting section of flash needs to be reserved.

The included memory.x works for S140 7.3.0 - the most recent version for the nRF52840 with the most flash usage out of all versions. So this should be a safe value and shouldn't brick anyone's chip.

Just to be sure, there is a warning inside the example's README.

---

Validated using a Seeed Studio XIAO nRF52840 via defmt-print:

<img width="1995" height="645" alt="1771269651_grim" src="https://github.com/user-attachments/assets/de1b7e02-5a20-4f21-b947-4c2cc6183c95" />
